### PR TITLE
Slightly changes README and fixes CMakeFiles.txt to work just fine.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,41 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
 find_package(OpenCV REQUIRED)
+
+if (OpenCV_FOUND)
+    # If the package has been found, several variables will
+    # be set, you can find the full list with descriptions
+    # in the OpenCVConfig.cmake file.
+    # Print some message showing some of them
+    message(STATUS "OpenCV library status:")
+    message(STATUS "    version: ${OpenCV_VERSION}")
+    message(STATUS "    include path: ${OpenCV_INCLUDE_DIRS}" \n)
+
+else ()
+    message(FATAL_ERROR "Could not locate OpenCV" \n)
+endif()
+
+set(Torch_DIR libtorch/share/cmake/Torch)
+find_package(Torch PATHS ${Torch_DIR} NO_DEFAULT REQUIRED)
+if (Torch_FOUND)
+    message(STATUS "Torch library found!")
+    message(STATUS "    include path: ${TORCH_INCLUDE_DIRS}" \n)
+
+else ()
+    message(FATAL_ERROR "Could not locate Torch" \n)
+endif()
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 set(CMAKE_PREFIX_PATH /home/nebula/libtorch)
 find_package(Torch REQUIRED)
 add_executable(YOLOv5LibTorch src/YOLOv5LibTorch.cpp)
 
 include_directories(
-${PROJECT_SOURCE_DIR}/include
-${OpenCV_INCLUDE_DIRS}
-)
+	${PROJECT_SOURCE_DIR}/include
+	${OpenCV_INCLUDE_DIRS}
+	${TORCH_INCLUDE_DIRS}
+	)
+
 
 target_link_libraries(YOLOv5LibTorch ${OpenCV_LIBS} ${TORCH_LIBRARIES})
 set_property(TARGET YOLOv5LibTorch PROPERTY CXX_STANDARD 14)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Real time object detection with deployment of YOLOv5 through LibTorch C++ API
 
 ### Getting Started
 
-1. Install OpenCV.
+1. Install OpenCV from apt repository or download it from source.
 
    ```shell
    sudo apt-get install libopencv-dev
@@ -19,9 +19,11 @@ Real time object detection with deployment of YOLOv5 through LibTorch C++ API
 2. Install LibTorch.
 
    ```shell
-   wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip
-   unzip libtorch-shared-with-deps-latest.zip
+   wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-shared-with-deps-latest.zip && unzip libtorch-shared-with-deps-latest.zip
    ```
+
+   It's far better to visit official [PyTorch website](https://pytorch.org/get-started/locally/) by yourself and download that version that suits your needs.
+   Note: OpenCV needs LibTorch version that has cxx11 ABI, otherwise compiler throws undefined references.
 
 3. Edit "CMakeLists.txt" to configure OpenCV and LibTorch correctly.
 


### PR DESCRIPTION
- README now has almost the same link, except this version of LibTorch library claims to comply to cxx11 ABI, so it might fix "Undefined reference to `cv::imread`" type of problem.
- CMakeLists.txt has rework based on my other (private) repository, that uses both OpenCV (v4.5.1) and LibTorch (v1.7.1) and compiles just fine. Newly utilises pkg-config. 